### PR TITLE
[Rogue] Declare "environ" with C linkage

### DIFF
--- a/Source/RogueC/Bootstrap/RogueC.h
+++ b/Source/RogueC/Bootstrap/RogueC.h
@@ -927,7 +927,7 @@ void Rogue_ignore_unused(T&) {}
         #include <spawn.h>
         #include <poll.h>
         #include <sys/wait.h>
-        extern char** environ;
+        extern "C" char** environ;
       #endif
       #ifdef ROGUE_PLATFORM_WINDOWS
         #define ROGUE_CONSOLE_FULL 0


### PR DESCRIPTION
I need this to get rogue to compile on linux, with:
```
➜ uname -r
5.4.0-70-generic
➜ g++ --version
g++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```